### PR TITLE
Provider should be called 'random' (not 'external')

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_version = ">= 0.13.0"
   required_providers {
-    external = {
+    random = {
       source  = "hashicorp/random"
       version = ">= 3.1.0"
     }


### PR DESCRIPTION
This PR avoids following warning:

╷
│ Warning: Duplicate required provider
│ 
│   on .terraform/modules/main.schema_registries.schema_registry_api_key.state_keeper/main.tf line 9:
│    9: resource "random_uuid" "module_id" {}
│ 
│ Provider "registry.terraform.io/hashicorp/random" was implicitly required via resource "random_uuid.module_id", but listed in required_providers as "external". Either the local name in required_providers must match the resource name, or the "external" provider must be assigned within the resource
│ block.
│ 
│ (and one more similar warning elsewhere)
╵
